### PR TITLE
Change the output type from Optional to Expected

### DIFF
--- a/docs/tutorial-basics/tutorial_02_basic_ports.md
+++ b/docs/tutorial-basics/tutorial_02_basic_ports.md
@@ -81,7 +81,7 @@ public:
   // Override the virtual function tick()
   NodeStatus tick() override
   {
-    Optional<std::string> msg = getInput<std::string>("message");
+    Expected<std::string> msg = getInput<std::string>("message");
     // Check if optional is valid. If not, throw its error
     if (!msg)
     {


### PR DESCRIPTION
`BT::Optional` was renamed to `BT::Expected` in V4 and this code snippet would not compile unless `USE_BTCPP3_OLD_NAMES` is defined according to [this](https://github.com/BehaviorTree/BehaviorTree.CPP/blob/0dd404b29c6a8e545ed60330577c39225ff4b3a4/include/behaviortree_cpp/basic_types.h#L205).