### PR TITLE
Fix small typo in subtree docs. "three -> tree"

### DIFF
--- a/docs/tutorial-basics/tutorial_05_subtrees.md
+++ b/docs/tutorial-basics/tutorial_05_subtrees.md
@@ -12,7 +12,7 @@ In other words, we want to create __hierarchical__ behavior trees and make
 our trees __composable__. 
 
 This can be achieved by defining multiple trees in the XML and using the
-node __SubTree__ to include one three into the other.
+node __SubTree__ to include one tree into the other.
 
 # CrossDoor behavior
 


### PR DESCRIPTION
Fixes tiny typo in subtree docs. 