### PR TITLE
fix typo in node type and name

### DIFF
--- a/docs/ros2_integration.md
+++ b/docs/ros2_integration.md
@@ -63,10 +63,10 @@ To create a BT Action that invokes this ROS Action:
 
 using namespace BT;
 
-class FinonacciAction: public RosActionNode<Fibonacci>
+class FibonacciAction: public RosActionNode<Fibonacci>
 {
 public:
-  FinonacciAction(const std::string& name,
+  FibonacciAction(const std::string& name,
                   const NodeConfig& conf,
                   const RosNodeParams& params)
     : RosActionNode<Fibonacci>(name, conf, params)
@@ -150,7 +150,7 @@ and other parameters using the `BT::RosNodeParams`:
   RosNodeParams params; 
   params.nh = node;
   params.default_port_value = "fibonacci";
-  factory.registerNodeType<SleepAction>("Sleep", params);
+  factory.registerNodeType<FibonacciAction>("Fibonacci", params);
 ```
 
 ## Asynchronous BT::Action using rclcpp::Client (services)


### PR DESCRIPTION
I assume Sleep is a left over copy/paste and should be FibonacciAction instead. changed the node name and related typos also.

In addition: `rclcpp::init(argc, argv);` is  needed to be called in main otherwise we get errors like 
```
terminate called after throwing an instance of 'rclcpp::exceptions::RCLInvalidArgument'
  what():  failed to create guard condition: context argument is null, at ./src/rcl/guard_condition.c:65
Aborted (core dumped)
```
I can add this to the pr also if it is ok

