### PR TITLE
Update "Integration with ROS2" to fix the examples

### DIFF
--- a/docs/ros2_integration.md
+++ b/docs/ros2_integration.md
@@ -48,18 +48,17 @@ should not worry about creating a separate thread.
 `TreeNode::halt()` and build reactive behaviors.
 
 Let's consider, for instance, the "Fibonacci" action client described in the
-[official C++ tutorial](https://docs.ros.org/en/humble/Tutorials/Intermediate/Writing-an-Action-Server-Client/Cpp.html#writing-an-action-client):
-
-```cpp
-// let's define these, for brevity
-using Fibonacci = action_tutorials_interfaces::action::Fibonacci;
-using GoalHandleFibonacci = rclcpp_action::ServerGoalHandle<Fibonacci>;
-```
+[official C++ tutorial](https://docs.ros.org/en/humble/Tutorials/Intermediate/Writing-an-Action-Server-Client/Cpp.html#writing-an-action-client).
 
 To create a BT Action that invokes this ROS Action:
 
 ```cpp
 #include <behaviortree_ros2/bt_action_node.hpp>
+#include "action_tutorials_interfaces/action/fibonacci.hpp"
+
+// let's define these, for brevity
+using Fibonacci = action_tutorials_interfaces::action::Fibonacci;
+using GoalHandleFibonacci = rclcpp_action::ServerGoalHandle<Fibonacci>;
 
 using namespace BT;
 
@@ -99,7 +98,7 @@ public:
     for (auto number : wr.result->sequence) {
       ss << number << " ";
     }
-    RCLCPP_INFO(node_->get_logger(), ss.str().c_str());
+    RCLCPP_INFO(logger(), ss.str().c_str());
     return NodeStatus::SUCCESS;
   }
 
@@ -110,7 +109,7 @@ public:
   // If not overridden, it will return FAILURE by default.
   virtual NodeStatus onFailure(ActionNodeErrorCode error) override
   {
-    RCLCPP_ERROR(node_->get_logger(), "Error: %d", error);
+    RCLCPP_ERROR(logger(), "Error: %d", error);
     return NodeStatus::FAILURE;
   }
 
@@ -128,7 +127,7 @@ public:
     for (auto number : feedback->partial_sequence) {
       ss << number << " ";
     }
-    RCLCPP_INFO(node_->get_logger(), ss.str().c_str());
+    RCLCPP_INFO(logger(), ss.str().c_str());
     return NodeStatus::RUNNING;
   }
 };
@@ -163,6 +162,7 @@ The example below is based on the
 
 ```cpp
 #include <behaviortree_ros2/bt_service_node.hpp>
+#include "example_interfaces/srv/add_two_ints.hpp"
 
 using AddTwoInts = example_interfaces::srv::AddTwoInts;
 using namespace BT;
@@ -203,7 +203,7 @@ class AddTwoIntsNode: public RosServiceNode<AddTwoInts>
   // It must return SUCCESS or FAILURE
   NodeStatus onResponseReceived(const Response::SharedPtr& response) override
   {
-    RCLCPP_INFO(node_->get_logger(), "Sum: %ld", response->sum);
+    RCLCPP_INFO(logger(), "Sum: %ld", response->sum);
     return NodeStatus::SUCCESS;
   }
 
@@ -214,7 +214,7 @@ class AddTwoIntsNode: public RosServiceNode<AddTwoInts>
   // If not overridden, it will return FAILURE by default.
   virtual NodeStatus onFailure(ServiceNodeErrorCode error) override
   {
-    RCLCPP_ERROR(node_->get_logger(), "Error: %d", error);
+    RCLCPP_ERROR(logger(), "Error: %d", error);
     return NodeStatus::FAILURE;
   }
 };


### PR DESCRIPTION
I was using https://www.behaviortree.dev/docs/ros2_integration to try and set up a basic first example on my side to integrate behavior trees with ROS2 using RosActionNode.

I had to make some changes to the code that is displayed on the page to make it work on my end, so I figured it might be useful to update the page to make it easier for future readers.

### Changes

#### 1. Adding include statement for the ROS2 action

I had to include the header file for the action by including `#include "action_tutorials_interfaces/action/fibonacci.hpp"` or else I would get an error when it ran the line `using Fibonacci = action_tutorials_interfaces::action::Fibonacci;`. 
I also had to add the line above the "using" statement, so I changed the documentation structure a bit.

This might be obvious for more experienced C++ developers, but for me, someone with limited C++ experience, it took a while to figure out this was missing on my end.

#### 2. Fixing the logging statements

Due to the use of weak pointers (I believe this was changed in BehaviorTree/BehaviorTree.ROS2@374edcf), the line to add ROS2 logs had to be updated.

### For info 
I've also added the same changes to the example using the RosServiceNode, but did not test these changes since I've only been looking into the RosActionNode. If required, I can do this.

First time open source contributor, so feel free to correct me where needed.