### PR TITLE
Fix declaration of providedPorts method in tutorial

### DIFF
--- a/docs/tutorial-basics/tutorial_02_basic_ports.md
+++ b/docs/tutorial-basics/tutorial_02_basic_ports.md
@@ -99,7 +99,7 @@ When a custom TreeNode has input and/or output ports, these ports must be
 declared in the __static__ method:
 
 ``` cpp
-static MyCustomNode::PortsList providedPorts();
+static PortsList MyCustomNode::providedPorts();
 ```
 
 The input from the port `message` can be read using the template method 


### PR DESCRIPTION
There was a type that caused confusion in understanding the concepts 

Earlier : static MyCustomNode::PortsList providedPorts(); This was incorrect
because PortsList is not in MyCustomNode, it is inside the namespace BT, 


And since it is declared  using namespace BT, this should be as follows
 static PortsList MyCustomNode::providedPorts();
 
 Or if namespace BT is not opened

staticBT::PortsList MyCustomNode::providedPorts();