### PR TITLE
Correction for named Functor As it was creating confusion and may mislead new learners.

### DIFF
--- a/docs/tutorial-basics/tutorial_01_first_tree.md
+++ b/docs/tutorial-basics/tutorial_01_first_tree.md
@@ -52,9 +52,9 @@ As you can see:
   It must always return a `NodeStatus`, i.e. RUNNING, SUCCESS or FAILURE. 
 
 Alternatively, we can use __dependency injection__ to create a TreeNode given 
-a function pointer (i.e. "functor"). 
+a function pointer. 
 
-The functor must have this signature:
+The Functions (to use as a function pointer) must have this signature:
 
 ``` cpp
 BT::NodeStatus myFunction(BT::TreeNode& self) 
@@ -98,7 +98,7 @@ private:
 
 ``` 
 
-We can build a `SimpleActionNode` from any of these functors:
+We can build a `SimpleActionNode` from any of these functions:
 
 - CheckBattery()
 - GripperInterface::open()


### PR DESCRIPTION
name functor is removed for function pointer, as it is defined for a class/struct which overloads function call operator '(…c)'.

In C++, a function pointer is not a "functor" in the common C++ sense, but both are types of callable objects. A functor (function object) is specifically a class or struct that overloads the function call operator()